### PR TITLE
Bugfix: Update element-resize-detector to 1.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "dependencies": {
-    "element-resize-detector": "^1.1.11",
+    "element-resize-detector": "^1.1.12",
     "invariant": "^2.2.2",
     "lodash": "^4.17.4"
   },


### PR DESCRIPTION
Motivation: make sure consumers get the fix for this issue: https://github.com/wnr/element-resize-detector/issues/68

Since this issue crashes applications in Firefox under certain circumstances, it would be nice to have the update explicit.