### PR TITLE
Fix for onSize not rendering children (Issue: #136)

### DIFF
--- a/src/sizeMe.js
+++ b/src/sizeMe.js
@@ -228,9 +228,8 @@ function sizeMe(config = defaultConfig) {
         if (this.strategy === 'callback') {
           this.callbackState = state
           this.props.onSize(state)
-        } else {
-          this.setState(state)
         }
+        this.setState(state)
       }
 
       strategisedGetState = () =>


### PR DESCRIPTION
Previously setState was not being called if the 'strategy' was a callback, causing the child components to not get rendered.

This fixes issue #136 for me