### PR TITLE
Change componentWillReceiveProps to componentDidUpdate

### DIFF
--- a/src/with-size.js
+++ b/src/with-size.js
@@ -190,11 +190,12 @@ function withSize(config = defaultConfig) {
         this.handleDOMNode(true)
       }
 
-      componentWillReceiveProps(nextProps) {
-        this.determineStrategy(nextProps)
-      }
-
       componentDidUpdate() {
+        /**
+         * Change component will mount to componentDidUpdate
+         * Based on https://github.com/reactjs/reactjs.org/issues/721
+         */
+        this.determineStrategy(this.props)
         this.handleDOMNode()
       }
 


### PR DESCRIPTION
#149 

Because componentWillReceiveProps will be deprecated soon, changes made is based on Dan Abramov's statement at https://github.com/reactjs/reactjs.org/issues/721 

> That’s the exact use case for componentDidUpdate and it’s more accurate than componentWillReceiveProps because it only fires when the prop has actually changed