### PR TITLE
Changed componentWillReceiveProps to componentDidUpdate

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -26,18 +26,18 @@ export default class SizeMe extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const {
       children: prevChildren,
       render: prevRender,
-      ...prevSizeMeConfig
+      ...currentSizeMeConfig
     } = this.props
     const {
       children: nextChildren,
       render: nextRender,
-      ...nextSizeMeConfig
-    } = nextProps
-    if (!isShallowEqual(prevSizeMeConfig, nextSizeMeConfig)) {
+      ...prevSizeMeConfig
+    } = prevProps
+    if (!isShallowEqual(currentSizeMeConfig, prevSizeMeConfig)) {
       this.createComponent(nextSizeMeConfig)
     }
   }

--- a/src/component.js
+++ b/src/component.js
@@ -38,7 +38,7 @@ export default class SizeMe extends Component {
       ...prevSizeMeConfig
     } = prevProps
     if (!isShallowEqual(currentSizeMeConfig, prevSizeMeConfig)) {
-      this.createComponent(nextSizeMeConfig)
+      this.createComponent(currentSizeMeConfig)
     }
   }
 


### PR DESCRIPTION
From the [React docs]()https://reactjs.org/docs/react-component.html:

>Note:
>
>These methods are considered legacy and you should avoid them in new code:
>
>UNSAFE_componentWillUpdate()
>UNSAFE_componentWillReceiveProps()

and

based on Dan Abramov's statement at [reactjs/reactjs.org#721](https://github.com/reactjs/reactjs.org/issues/721)

> That’s the exact use case for componentDidUpdate and it’s more accurate than componentWillReceiveProps because it only fires when the prop has actually changed