### PR TITLE
Fix an error for old firefox which doesn't have isSameNode method

### DIFF
--- a/src/with-size.js
+++ b/src/with-size.js
@@ -257,7 +257,10 @@ function withSize(config = defaultConfig) {
         if (!this.domEl) {
           this.domEl = found
           this.detector.listenTo(this.domEl, this.checkIfSizeChanged)
-        } else if (!this.domEl.isSameNode(found)) {
+        } else if (
+          (this.domEl.isSameNode && !this.domEl.isSameNode(found)) ||
+          (!this.domEl.isSameNode && this.domEl !== found)
+        ) {
           this.uninstall()
           this.domEl = found
           this.detector.listenTo(this.domEl, this.checkIfSizeChanged)


### PR DESCRIPTION
Hello~
I've been using react-sizeme for almost 1 year now.
It's such a great react components for me.

BTW, There is an issue for old firefox browsers.
I found out this bug because my clients are still using old machines :(

I hope you could accept my pull request so I don't modify react-sizeme sources in node_modules folder everytime I build my application

Thank you in advance