### PR TITLE
Export noPlaceholders global variable in react-sizeme.d.ts

### DIFF
--- a/react-sizeme.d.ts
+++ b/react-sizeme.d.ts
@@ -31,6 +31,8 @@ declare namespace sizeMe {
   ) => <P extends object = {}>(
     component: ComponentType<P>,
   ) => ComponentType<Omit<P, 'size'>>
+
+  export let noPlaceholders: boolean
 }
 declare function sizeMe(
   options?: sizeMe.SizeMeOptions,


### PR DESCRIPTION
Thanks for your work providing this component! I am using it successfully in a TypeScript project. 

For testing purposes, we disable the placeholder mechanism as described in https://github.com/ctrlplusb/react-sizeme#server-side-rendering in our jest `setupTests.ts` file. As the global variable is not defined in react-sizeme.d.ts, the TypeScript compiler complains and we temporarily silenced it by adding `// @ts-ignore`. This PR should fix this issue for good and allow us to remove the ts-ignore.